### PR TITLE
fix(blog): replace untyped params in get_or_create_tag with TagCreate schema

### DIFF
--- a/backend/app/crud/post.py
+++ b/backend/app/crud/post.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, func, select
 
 from app.models.post import Post, PostTagLink, Tag
-from app.schemas.post import PostUpsert
+from app.schemas.post import PostUpsert, TagCreate
 
 
 def get_post_by_slug(*, session: Session, slug: str) -> Post | None:
@@ -57,12 +57,12 @@ def upsert_post(*, session: Session, source_path: str, data: PostUpsert) -> Post
     return post
 
 
-def get_or_create_tag(*, session: Session, name: str, slug: str) -> Tag:
-    statement = select(Tag).where(Tag.slug == slug)
+def get_or_create_tag(*, session: Session, data: TagCreate) -> Tag:
+    statement = select(Tag).where(Tag.slug == data.slug)
     existing = session.exec(statement).first()
     if existing:
         return existing
-    tag = Tag(name=name, slug=slug)
+    tag = Tag(name=data.name, slug=data.slug)
     session.add(tag)
     session.commit()
     session.refresh(tag)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -5,6 +5,7 @@ from app.schemas.post import (  # noqa: F401
     PostPublic,
     PostsPublic,
     PostUpsert,
+    TagCreate,
     TagPublic,
     TagWithCount,
 )

--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -14,6 +14,11 @@ class PostUpsert(SQLModel):
     published_at: datetime | None = None
 
 
+class TagCreate(SQLModel):
+    name: str
+    slug: str
+
+
 class TagPublic(SQLModel):
     id: uuid.UUID
     name: str

--- a/backend/tests/crud/test_post.py
+++ b/backend/tests/crud/test_post.py
@@ -9,7 +9,7 @@ from app.crud.post import (
     get_tags_with_counts,
     upsert_post,
 )
-from app.schemas.post import PostUpsert
+from app.schemas.post import PostUpsert, TagCreate
 from tests.utils.utils import random_lower_string
 
 
@@ -98,7 +98,7 @@ def test_get_posts_published_only(db: Session) -> None:
 def test_get_or_create_tag_creates(db: Session) -> None:
     name = f"Tag {random_lower_string()}"
     slug = f"tag-{random_lower_string()}"
-    tag = get_or_create_tag(session=db, name=name, slug=slug)
+    tag = get_or_create_tag(session=db, data=TagCreate(name=name, slug=slug))
     assert tag.id is not None
     assert tag.name == name
     assert tag.slug == slug
@@ -107,14 +107,16 @@ def test_get_or_create_tag_creates(db: Session) -> None:
 def test_get_or_create_tag_returns_existing(db: Session) -> None:
     name = f"Tag {random_lower_string()}"
     slug = f"tag-{random_lower_string()}"
-    tag1 = get_or_create_tag(session=db, name=name, slug=slug)
-    tag2 = get_or_create_tag(session=db, name=name, slug=slug)
+    tag1 = get_or_create_tag(session=db, data=TagCreate(name=name, slug=slug))
+    tag2 = get_or_create_tag(session=db, data=TagCreate(name=name, slug=slug))
     assert tag1.id == tag2.id
 
 
 def test_get_tags_with_counts(db: Session) -> None:
     tag_slug = f"tag-{random_lower_string()}"
-    tag = get_or_create_tag(session=db, name=f"Tag {tag_slug}", slug=tag_slug)
+    tag = get_or_create_tag(
+        session=db, data=TagCreate(name=f"Tag {tag_slug}", slug=tag_slug)
+    )
 
     post_data = _post_data(published=True)
     post = upsert_post(
@@ -134,7 +136,9 @@ def test_get_tags_with_counts(db: Session) -> None:
 
 def test_get_posts_filtered_by_tag(db: Session) -> None:
     tag_slug = f"filter-{random_lower_string()}"
-    tag = get_or_create_tag(session=db, name=f"Filter {tag_slug}", slug=tag_slug)
+    tag = get_or_create_tag(
+        session=db, data=TagCreate(name=f"Filter {tag_slug}", slug=tag_slug)
+    )
 
     tagged_slug = f"tagged-{random_lower_string()}"
     tagged_post = upsert_post(


### PR DESCRIPTION
## Summary
Adds a `TagCreate` schema and updates `get_or_create_tag` to accept it instead of raw `name: str, slug: str` parameters — same pattern applied to posts/projects in #17.

## Changes
- Add `TagCreate` schema in `schemas/post.py` with `name` and `slug` fields
- Update `get_or_create_tag` CRUD function to accept `data: TagCreate`
- Re-export `TagCreate` from `schemas/__init__.py`
- Update all 4 test call sites to use the typed schema

## Notes
Partial progress on #5 — remaining `PostCreate`/`PostUpdate` and `ProjectCreate`/`ProjectUpdate` schemas are deferred to Phase 3 (API routes).