### PR TITLE
refactor(blog): use pydantic BaseModel for response-only schemas

### DIFF
--- a/backend/app/schemas/post.py
+++ b/backend/app/schemas/post.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
 
-from pydantic import Field
-from sqlmodel import SQLModel
+from pydantic import BaseModel, ConfigDict
+from sqlmodel import Field, SQLModel
 
 
 class PostUpsert(SQLModel):
@@ -20,7 +20,9 @@ class TagCreate(SQLModel):
     slug: str = Field(max_length=100)
 
 
-class TagPublic(SQLModel):
+class TagPublic(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: uuid.UUID
     name: str
     slug: str
@@ -30,7 +32,9 @@ class TagWithCount(TagPublic):
     post_count: int
 
 
-class PostPublic(SQLModel):
+class PostPublic(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: uuid.UUID
     title: str
     slug: str
@@ -46,6 +50,6 @@ class PostDetail(PostPublic):
     content_html: str
 
 
-class PostsPublic(SQLModel):
+class PostsPublic(BaseModel):
     data: list[PostPublic]
     count: int

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
 
-from pydantic import Field
-from sqlmodel import SQLModel
+from pydantic import BaseModel, ConfigDict
+from sqlmodel import Field, SQLModel
 
 
 class ProjectUpsert(SQLModel):
@@ -17,7 +17,9 @@ class ProjectUpsert(SQLModel):
     sort_order: int = 0
 
 
-class ProjectPublic(SQLModel):
+class ProjectPublic(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: uuid.UUID
     title: str
     slug: str
@@ -30,6 +32,6 @@ class ProjectPublic(SQLModel):
     updated_at: datetime | None = None
 
 
-class ProjectsPublic(SQLModel):
+class ProjectsPublic(BaseModel):
     data: list[ProjectPublic]
     count: int


### PR DESCRIPTION
## Summary

- Switch response-only schemas (`TagPublic`, `PostPublic`, `PostDetail`, `PostsPublic`, `ProjectPublic`, `ProjectsPublic`) from `SQLModel` to `pydantic.BaseModel`
- Add `ConfigDict(from_attributes=True)` to schemas that serialize ORM instances (`TagPublic`, `PostPublic`, `ProjectPublic`)
- Write schemas (`PostUpsert`, `TagCreate`, `ProjectUpsert`) remain on `SQLModel`

Closes #8

## Test plan

- [x] `make test-fast` — 95 tests pass
- [x] `make lint` — clean (ty + ruff)
- [x] Review agent validated correct schema split and import consistency