### PR TITLE
refactor(auth): replace -> Any return types with explicit types in route handlers

### DIFF
--- a/backend/app/api/routes/login.py
+++ b/backend/app/api/routes/login.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import HTMLResponse
@@ -8,6 +8,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from app.api.deps import CurrentUser, SessionDep, get_current_active_superuser
 from app.core import security
 from app.core.config import settings
+from app.models import User
 from app.schemas import Message, NewPassword, Token, UserPublic
 from app.services import auth as auth_service
 
@@ -33,7 +34,7 @@ def login_access_token(
 
 
 @router.post("/login/test-token", response_model=UserPublic)
-def test_token(current_user: CurrentUser) -> Any:
+def test_token(current_user: CurrentUser) -> User:
     """
     Test access token
     """
@@ -65,7 +66,7 @@ def reset_password(session: SessionDep, body: NewPassword) -> Message:
     dependencies=[Depends(get_current_active_superuser)],
     response_class=HTMLResponse,
 )
-def recover_password_html_content(email: str, session: SessionDep) -> Any:
+def recover_password_html_content(email: str, session: SessionDep) -> HTMLResponse:
     """
     HTML Content for Password Recovery
     """

--- a/backend/app/api/routes/private.py
+++ b/backend/app/api/routes/private.py
@@ -1,10 +1,9 @@
-from typing import Any
-
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 from app import crud
 from app.api.deps import SessionDep
+from app.models import User
 from app.schemas import UserCreate, UserPublic
 
 router = APIRouter(tags=["private"], prefix="/private")
@@ -18,7 +17,7 @@ class PrivateUserCreate(BaseModel):
 
 
 @router.post("/users/", response_model=UserPublic)
-def create_user(user_in: PrivateUserCreate, session: SessionDep) -> Any:
+def create_user(user_in: PrivateUserCreate, session: SessionDep) -> User:
     """
     Create a new user.
     """

--- a/backend/app/api/routes/users.py
+++ b/backend/app/api/routes/users.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Any
 
 from fastapi import APIRouter, Depends
 
@@ -8,6 +7,7 @@ from app.api.deps import (
     SessionDep,
     get_current_active_superuser,
 )
+from app.models import User
 from app.schemas import (
     Message,
     UpdatePassword,
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/users", tags=["users"])
     dependencies=[Depends(get_current_active_superuser)],
     response_model=UsersPublic,
 )
-def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
+def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> UsersPublic:
     """
     Retrieve users.
     """
@@ -39,7 +39,7 @@ def read_users(session: SessionDep, skip: int = 0, limit: int = 100) -> Any:
 @router.post(
     "/", dependencies=[Depends(get_current_active_superuser)], response_model=UserPublic
 )
-def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
+def create_user(*, session: SessionDep, user_in: UserCreate) -> User:
     """
     Create new user.
     """
@@ -49,7 +49,7 @@ def create_user(*, session: SessionDep, user_in: UserCreate) -> Any:
 @router.patch("/me", response_model=UserPublic)
 def update_user_me(
     *, session: SessionDep, user_in: UserUpdateMe, current_user: CurrentUser
-) -> Any:
+) -> User:
     """
     Update own user.
     """
@@ -61,7 +61,7 @@ def update_user_me(
 @router.patch("/me/password", response_model=Message)
 def update_password_me(
     *, session: SessionDep, body: UpdatePassword, current_user: CurrentUser
-) -> Any:
+) -> Message:
     """
     Update own password.
     """
@@ -75,7 +75,7 @@ def update_password_me(
 
 
 @router.get("/me", response_model=UserPublic)
-def read_user_me(current_user: CurrentUser) -> Any:
+def read_user_me(current_user: CurrentUser) -> User:
     """
     Get current user.
     """
@@ -83,7 +83,7 @@ def read_user_me(current_user: CurrentUser) -> Any:
 
 
 @router.delete("/me", response_model=Message)
-def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
+def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Message:
     """
     Delete own user.
     """
@@ -92,7 +92,7 @@ def delete_user_me(session: SessionDep, current_user: CurrentUser) -> Any:
 
 
 @router.post("/signup", response_model=UserPublic)
-def register_user(session: SessionDep, user_in: UserRegister) -> Any:
+def register_user(session: SessionDep, user_in: UserRegister) -> User:
     """
     Create new user without the need to be logged in.
     """
@@ -102,7 +102,7 @@ def register_user(session: SessionDep, user_in: UserRegister) -> Any:
 @router.get("/{user_id}", response_model=UserPublic)
 def read_user_by_id(
     user_id: uuid.UUID, session: SessionDep, current_user: CurrentUser
-) -> Any:
+) -> User:
     """
     Get a specific user by id.
     """
@@ -121,7 +121,7 @@ def update_user(
     session: SessionDep,
     user_id: uuid.UUID,
     user_in: UserUpdate,
-) -> Any:
+) -> User:
     """
     Update a user.
     """


### PR DESCRIPTION
## Summary
Replaces all `-> Any` return type annotations with explicit types across route handlers, enforcing the project convention of no `Any` return types.

## Changes
- Replace 9 `-> Any` annotations in `users.py` with `UsersPublic`, `User`, or `Message`
- Replace 2 `-> Any` annotations in `login.py` with `User` and `HTMLResponse`
- Replace 1 `-> Any` annotation in `private.py` with `User`
- Remove unused `from typing import Any` imports, add `from app.models import User`

## Notes
Closes #7. Handlers retain `response_model=UserPublic` on decorators for serialization — return type annotations reflect what the function actually returns (`User`), not the response shape.