### PR TITLE
chore(core): remove sentry dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,6 @@ POSTGRES_DB=app
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=changethis
 
-SENTRY_DSN=
-
 # Logging
 LOG_LEVEL=INFO
 LOG_FORMAT=console

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
       SMTP_USER: ""
       SMTP_PASSWORD: ""
       EMAILS_FROM_EMAIL: test@example.com
-      SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,7 +6,6 @@ from pydantic import (
     AnyUrl,
     BeforeValidator,
     EmailStr,
-    HttpUrl,
     PostgresDsn,
     SecretStr,
     computed_field,
@@ -77,7 +76,6 @@ class Settings(BaseSettings):
         ]
 
     PROJECT_NAME: str
-    SENTRY_DSN: HttpUrl | None = None
     POSTGRES_SERVER: str
     POSTGRES_PORT: int = 5432
     POSTGRES_USER: str

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,3 @@
-import sentry_sdk
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 from fastapi.routing import APIRoute
@@ -23,10 +22,6 @@ setup_logging(
     json_output=settings.LOG_FORMAT == "json",
 )
 
-# 2. Sentry (unchanged)
-if settings.SENTRY_DSN and settings.ENVIRONMENT != "local":
-    sentry_sdk.init(dsn=str(settings.SENTRY_DSN), enable_tracing=True)
-
 
 def custom_generate_unique_id(route: APIRoute) -> str:
     if route.tags:
@@ -34,17 +29,17 @@ def custom_generate_unique_id(route: APIRoute) -> str:
     return route.name
 
 
-# 3. Create app
+# 2. Create app
 app = FastAPI(
     title=settings.PROJECT_NAME,
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     generate_unique_id_function=custom_generate_unique_id,
 )
 
-# 4. Exception handlers (RFC 9457 Problem Details)
+# 3. Exception handlers (RFC 9457 Problem Details)
 register_exception_handlers(app)
 
-# 5. Middleware — last-added runs first, so add order is:
+# 4. Middleware — last-added runs first, so add order is:
 #    Metrics → RequestLogging → TraceId → CORS
 #    Execution order: CORS → TraceId → RequestLogging → Metrics
 app.add_middleware(MetricsMiddleware)  # type: ignore[arg-type]
@@ -59,10 +54,10 @@ if settings.all_cors_origins:
         allow_headers=["*"],
     )
 
-# 6. OpenTelemetry (no-op if OTEL_ENABLED=false)
+# 5. OpenTelemetry (no-op if OTEL_ENABLED=false)
 setup_observability(app)
 
-# 7. Routers
+# 6. Routers
 app.include_router(api_router, prefix=settings.API_V1_STR)
 app.include_router(pages_router)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "psycopg[binary]<4.0.0,>=3.1.13",
     "sqlmodel<1.0.0,>=0.0.21",
     "pydantic-settings<3.0.0,>=2.2.1",
-    "sentry-sdk[fastapi]>=2.0.0,<3.0.0",
     "pyjwt<3.0.0,>=2.8.0",
     "pwdlib[argon2,bcrypt]>=0.3.0",
     "structlog>=24.1.0,<25.0.0",

--- a/compose.yml
+++ b/compose.yml
@@ -109,7 +109,6 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
-      - SENTRY_DSN=${SENTRY_DSN}
 
   backend:
     image: '${DOCKER_IMAGE_BACKEND?Variable not set}:${TAG-latest}'
@@ -142,7 +141,6 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER?Variable not set}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD?Variable not set}
-      - SENTRY_DSN=${SENTRY_DSN}
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/utils/health-check/"]

--- a/uv.lock
+++ b/uv.lock
@@ -85,7 +85,6 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlmodel" },
     { name = "structlog" },
     { name = "tenacity" },
@@ -123,7 +122,6 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.8.0,<3.0.0" },
     { name = "python-multipart", specifier = ">=0.0.7,<1.0.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0,<3.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.21,<1.0.0" },
     { name = "structlog", specifier = ">=24.1.0,<25.0.0" },
     { name = "tenacity", specifier = ">=8.2.3,<9.0.0" },
@@ -2185,11 +2183,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/eb/1b497650eb564701f9a7b8a95c51b2abe9347ed2c0b290ba78f027ebe4ea/sentry_sdk-2.52.0.tar.gz", hash = "sha256:fa0bec872cfec0302970b2996825723d67390cdd5f0229fb9efed93bd5384899", size = 410273, upload-time = "2026-02-04T15:03:54.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/63/2c6daf59d86b1c30600bff679d039f57fd1932af82c43c0bde1cbc55e8d4/sentry_sdk-2.52.0-py2.py3-none-any.whl", hash = "sha256:931c8f86169fc6f2752cb5c4e6480f0d516112e78750c312e081ababecbaf2ed", size = 435547, upload-time = "2026-02-04T15:03:51.567Z" },
-]
-
-[package.optional-dependencies]
-fastapi = [
-    { name = "fastapi" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Remove unused Sentry dependency inherited from the full-stack-fastapi-template. OTEL observability stack (#32) fully replaces it.

## Changes
- Remove `sentry-sdk[fastapi]` from `pyproject.toml` and regenerate lock file
- Remove Sentry import and init block from `main.py`
- Remove `SENTRY_DSN` setting from `config.py` (and unused `HttpUrl` import)
- Remove `SENTRY_DSN` env vars from `compose.yml`, `.env.example`, and CI workflow

## Notes
Closes #33